### PR TITLE
docs: Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ export {
 ##  React Native & Expo Support
 
 `telemetrydeck-react` also supports React Native or Expo.
-If no global implementation is available because you are not on the web, TelemetryDeck needs a subtle implementation which can be either injected by extending `globalThis or added to the TelemetryDeck instance.
+If no global implementation is available because you are not on the web, TelemetryDeck needs a subtle implementation which can be either injected by extending `globalThis` or added to the TelemetryDeck instance.
 
 In the React Native context, a TextEncoder is also needed for it to work properly.
 


### PR DESCRIPTION
The following sentence: 

> TelemetryDeck needs a subtle implementation which can be either injected by extending `globalThis` or added to the TelemetryDeck instance.

was missing a backtick to highlight `globalThis` <3