### PR TITLE
fix: export plugins

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,10 +2,12 @@ import { TelemetryDeckContext } from "./telemetrydeck-context";
 import { TelemetryDeckProvider } from "./telemetrydeck-provider";
 import { createTelemetryDeck } from "./create-telemetrydeck";
 import { useTelemetryDeck } from "./use-telemetrydeck";
+import { browserPlugin } from "./plugins";
 
 export {
   TelemetryDeckContext,
   TelemetryDeckProvider,
   createTelemetryDeck,
   useTelemetryDeck,
+  browserPlugin,
 };


### PR DESCRIPTION
This Pull Request fixes an issue where users were not able to import plugins to include in their TelemetryDeck initialization.