### PR TITLE
feat: allow for not defining the client user when utilizing the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TelemetryDeck React
-A library for using TelemetryDeck in your React app.
+A library for easily integrating [TelemetryDeck](https://telemetrydeck.com/) into your React application.
 
 ## Installation
 
@@ -14,13 +14,16 @@ To set up this library, simply create a TelemetryDeck instance with the factory 
 ```tsx
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { TelemetryDeckProvider, createTelemetryDeck } from '@typedigital/telemetrydeck-react';
+import { TelemetryDeckProvider, createTelemetryDeck } from '@telemetrydeck/react';
 import { Dashboard } from './Dashboard';
 
-const td = createTelemetryDeck({app: process.env.APP_ID, user: 'anonymous'});
+// Create the TelemetryDeck instance
+const td = createTelemetryDeck({
+  appID: "YOUR-APP-ID", // Replace with your actual App ID
+  clientUser: "anonymous" // A unique identifier for the user
+});
 
 const App = () => {
-
   return (
     <div>
       <TelemetryDeckProvider telemetryDeck={td}>
@@ -33,46 +36,137 @@ const App = () => {
 ReactDOM.render(<App />, document.getElementById('root'));
 ```
 
+## Configuration
+
+| Parameter   | Type                          | Required    | Description                                                                                                                                         |
+|-------------|-------------------------------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| appID       | string                        | Yes         | Your unique App ID from TelemetryDeck.                                                                                                              |
+| clientUser  | string                        | Conditional | An identifier for the current user. Optional if using the browserPlugin, which generates a stable anonymous ID automatically.                        |
+| testMode    | boolean                       | No          | Puts the instance in test mode. Defaults to true if the app is running on localhost or 127.0.0.1, and false otherwise.                               |
+| plugins     | TelemetryDeckReactSDKPlugin[] | No          | An array of plugins to extend functionality and automatically enrich signal payloads (see the "Plugins" section below).                             |
+
+
 ## Basic usage
 
-To send signals, use the `useTelemetryDeck` hook and destructure the various methods that can be used to modify the instance or send signals to TelemetryDeck.
+To send signals, use the `useTelemetryDeck` hook and destructure the various methods `signal`, `queue` and `flush` to TelemetryDeck.
 For more information, see the [TelemetryDeck documentation](https://telemetrydeck.com/docs/).
+
+### `signal`: Sending Immediately
+The `signal` function sends an event to the TelemetryDeck API right away.
 
 ```tsx
 import * as React from 'react';
-import { useTelemetryDeck } from '@typedigital/telemetrydeck-react';
-
+import { useTelemetryDeck } from '@telemetrydeck/react';
 
 function Dashboard() {
-
   const { signal } = useTelemetryDeck();
 
-  const clickHandler = async () => {
-    const res = await signal('click', { event: 'button-click', target: 'Call to Action' })
-    console.log(res); // the response of the TelemetryDeck API
+  // Example: Send a click event
+  const handleClick = async () => {
+    // The first argument is the signal type (a short, descriptive string)
+    // The second argument (optional) is a payload object with additional data
+    const response = await signal('buttonClicked', { component: 'CallToAction' });
+    console.log(response); // The response from the TelemetryDeck API
   }
 
-  // If you want to track if a user saw a certain page or component just use an effect
+  // Example: Track a page view when the component mounts
   React.useEffect(() => {
-    (async () => {
-      const { pathname } = window.location;
-      await signal('pageview', { component: 'dashboard', path: pathname });
-    })();
-  }, [])
+    const { pathname } = window.location;
+    signal('pageView', { component: 'Dashboard', path: pathname });
+  }, [signal]);
 
   return (
-    <React.Fragment>
+    <>
       <h1>My Dashboard</h1>
-      <button onClick={async () => await clickHandler()}>
-        Click me
+      <button onClick={handleClick}>
+        Click Me
       </button>
-    </React.Fragment>
-  )
+    </>
+  );
 }
+```
 
-export {
-  Dashboard
+### `queue` & `flush`: Batching Signals
+You can collect multiple signals and send them together in a single network request. This is useful for reducing network traffic.
+
+1. `queue(type, payload)`: Adds a signal to an internal queue without sending it.
+
+2. `flush()`: Sends all signals currently in the queue to the API.
+
+```tsx
+import { useTelemetryDeck } from '@telemetrydeck/react';
+
+function AnalyticsComponent() {
+  const { queue, flush } = useTelemetryDeck();
+
+  const handleComplexAction = () => {
+    // Add multiple signals to the queue
+    queue('actionStarted', { step: 1 });
+    queue('intermediateStep', { step: 2 });
+    queue('actionCompleted', { step: 3 });
+
+    // Send all queued signals at once
+    flush();
+  };
+
+  return <button onClick={handleComplexAction}>Perform Complex Action</button>;
 }
+```
+
+## Plugins
+Plugins are a powerful way to automatically enrich every signal payload with additional data. This is ideal for context you want to include with every signal, such as browser information or app versions.
+
+### Using the Browser Plugin
+We provide a browserPlugin that automatically collects useful context from the user's browser.
+
+### Features:
+
+Automatic User ID: If you omit `clientUser` from your configuration, the plugin will generate a stable, anonymous ID for the user based on browser properties.
+
+Contextual Data: Automatically adds details like browser name, version, OS, and device type to every signal.
+
+```tsx
+import { createTelemetryDeck, browserPlugin } from '@telemetrydeck/react';
+
+// Configure TelemetryDeck with the browser plugin
+const td = createTelemetryDeck({
+  appID: "YOUR-APP-ID",
+  plugins: [browserPlugin]
+  // clientUser is optional here!
+});
+
+```
+
+### Creating Custom Plugins
+
+You can easily create your own plugins. A plugin is a function that takes the next function in the chain and modifies the payload.
+
+Here's an example of a plugin that adds a Git commit hash to every signal:
+
+```tsx
+import { TelemetryDeckReactSDKPlugin } from '@telemetrydeck/react';
+
+// Get the Git hash (e.g., from an environment variable)
+const commitHash = process.env.REACT_APP_COMMIT_HASH;
+
+// Define your custom plugin
+const gitVersionPlugin: TelemetryDeckReactSDKPlugin = (next) => (payload) => {
+  // Call the next function to get the recursively enhanced payload
+  const enhancedPayload = next(payload);
+
+  // Add your custom data
+  return {
+    ...enhancedPayload,
+    gitCommit: commitHash,
+  };
+};
+
+// Use your plugin during initialization
+const td = createTelemetryDeck({
+  appID: "YOUR-APP-ID",
+  clientUser: "anonymous",
+  plugins: [gitVersionPlugin] // You can combine multiple plugins
+});
 ```
 
 ##  React Native & Expo Support
@@ -126,4 +220,8 @@ MIT
 
 ## Sponsors
 
-[<img src="https://typedig.uber.space/assets/71ff4706-43e0-46f5-bab5-0fe6f07ad016" width=150 />](https://typedigital.de)
+<div style="background-color: #ffffff; padding: 10px; width: 350px; height: 65px">
+
+[<img src="https://typedigital.de/static/13fdfb01fd88e0f50b8d7d09cce92b58/a9476/Typedigital-Logo-Paket.webp" width=350 />](https://typedigital.de)
+
+</div>

--- a/src/create-telemetrydeck.ts
+++ b/src/create-telemetrydeck.ts
@@ -1,19 +1,17 @@
+/* eslint-disable @typescript-eslint/unified-signatures */
+/* eslint-disable tsdoc/syntax */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import TelemetryDeck, { TelemetryDeckOptions } from "@telemetrydeck/sdk";
+import TelemetryDeck from "@telemetrydeck/sdk";
 import { LIB_VERSION } from "./version";
 import validatePlugin from "./plugins/validate";
-
-type PayloadEnhancer = (payload: Record<string, unknown>) => Record<string, unknown>;
-
-type TelemetryDeckReactSDKPlugin = (next: PayloadEnhancer) => PayloadEnhancer;
-
-type TelemetryDeckReactSDKOptions = TelemetryDeckOptions & {
-  plugins?: TelemetryDeckReactSDKPlugin[],
-};
-
-type TelemetryDeckReactSDK = TelemetryDeck & {
-  payloadEnhancer?: PayloadEnhancer,
-};
+import {
+  PayloadEnhancer,
+  OptionsWithBrowserPlugin,
+  TelemetryDeckReactSDK,
+  OptionsWithRequiredUser,
+  TelemetryDeckReactSDKPlugin,
+  TelemetryDeckReactSDKOptions,
+} from "./types";
 
 /**
  * Creates the base enhancer function which adds the library version.
@@ -36,17 +34,55 @@ const isLocalhost = () => {
   return undefined;
 };
 
+const generateIdentifierString = (): string => {
+  const osMatch = window.navigator.userAgent.match(/\(([^)]+)\)/);
+  const platform = osMatch?.[1] ? osMatch[1].split("; ")[0] : null;
+  const screenResolution = `${window.screen.width}x${window.screen.height}`;
+
+  const identifierString = [
+    platform || navigator.platform,
+    window.navigator.hardwareConcurrency.toString(),
+    screenResolution,
+  ].join("");
+
+  return identifierString;
+};
+
+/**
+ * Creates TelemetryDeck instance signature for when the browser plugin is used.
+ * @param options The configuration has an optional `clientUser`.
+ */
+function createTelemetryDeck(options: OptionsWithBrowserPlugin): TelemetryDeckReactSDK;
+
+/**
+ * Creates TelemetryDeck instance signature for the default case.
+ * @param options The configuration has a required `clientUser`.
+ */
+function createTelemetryDeck(options: OptionsWithRequiredUser): TelemetryDeckReactSDK;
+
+/**
+ * The implementation of our createTelemetryDeck function accepting both options as a Union.
+ */
 function createTelemetryDeck(
-  options: TelemetryDeckReactSDKOptions,
+  options: OptionsWithBrowserPlugin | OptionsWithRequiredUser,
 ): TelemetryDeckReactSDK {
-  const { plugins, appID, ...opts } = options;
+  const { plugins, appID, clientUser, ...opts } = options;
   if (!appID) {
     throw new Error("appId has to be defined");
   }
   (plugins ?? []).forEach(validatePlugin);
 
+  /**
+   * Check for browser plugin to be set to allow for generation of a default identifier for our user
+   * based on the userAgent only accessible in browsers
+   */
+  const hasBrowserPlugin = (plugins ?? []).some(
+    (plugin) => plugin.name === "@telemetrydeck/browser",
+  );
+  const user = clientUser ?? (hasBrowserPlugin ? generateIdentifierString() : "anonymous");
+
   const testMode = opts.testMode === undefined ? isLocalhost() : opts.testMode;
-  const telemetrydeck = new TelemetryDeck({ appID, testMode, ...opts });
+  const telemetrydeck = new TelemetryDeck({ appID, clientUser: user, testMode, ...opts });
 
   // This conversion to TelemetryDeckReactSDK is done in order to allow adding our plugins to the response
   const telemetryDeckReactSDK: TelemetryDeckReactSDK = telemetrydeck;

--- a/src/plugins/browser-plugin.ts
+++ b/src/plugins/browser-plugin.ts
@@ -1,9 +1,14 @@
 /* eslint-disable max-len */
-import { PayloadEnhancer, TelemetryDeckReactSDKPlugin } from "src/create-telemetrydeck";
+import { PayloadEnhancer } from "src/create-telemetrydeck";
 
 type BrowserDetails = {
   browserName: "Opera" | "Edge" | "Chrome" | "Safari" | "Firefox",
   browserVersion: string,
+};
+
+type BrowserPlugin = {
+  (next: PayloadEnhancer): PayloadEnhancer,
+  name: "@telemetrydeck/browser",
 };
 
 // function extracting browser information from the User-Agent-String
@@ -115,14 +120,19 @@ const getBrowserInfo = (): Record<string, string | null> => {
   };
 };
 
-const browserPlugin: TelemetryDeckReactSDKPlugin = (next: PayloadEnhancer) => (payload: Record<string, unknown>) => {
+const pluginFunction = (next: PayloadEnhancer) => (payload: Record<string, unknown>): Record<string, unknown> => {
   // eslint-disable-next-line callback-return
   const enhancedPayload = next(payload);
-
   return {
     ...enhancedPayload,
     ...getBrowserInfo(),
   };
 };
 
+Object.setPrototypeOf(pluginFunction, { name: "@telemetrydeck/browser" });
+
+const browserPlugin = pluginFunction as BrowserPlugin;
+
 export { browserPlugin };
+
+export type { BrowserPlugin };

--- a/src/plugins/browser-plugin.ts
+++ b/src/plugins/browser-plugin.ts
@@ -8,7 +8,7 @@ type BrowserDetails = {
 
 type BrowserPlugin = {
   (next: PayloadEnhancer): PayloadEnhancer,
-  name: "@telemetrydeck/browser",
+  name: "@typedigital/browser",
 };
 
 // function extracting browser information from the User-Agent-String

--- a/src/plugins/browser-plugin.ts
+++ b/src/plugins/browser-plugin.ts
@@ -129,7 +129,7 @@ const pluginFunction = (next: PayloadEnhancer) => (payload: Record<string, unkno
   };
 };
 
-Object.setPrototypeOf(pluginFunction, { name: "@telemetrydeck/browser" });
+Object.setPrototypeOf(pluginFunction, { name: "@typedigital/browser" });
 
 const browserPlugin = pluginFunction as BrowserPlugin;
 

--- a/src/tests/telemetrydeck-browser-plugin.test.tsx
+++ b/src/tests/telemetrydeck-browser-plugin.test.tsx
@@ -156,3 +156,25 @@ test.each(testCases)("$name", async (testCase) => {
 
   server.events.removeAllListeners("request:start");
 });
+
+test("Given createTelemetryDeck is initialized without a clientUser, when a signal is sent, then the clientUser in the payload is a generated hash", async () => {
+  const td = createTelemetryDeck({ appID, plugins: [browserPlugin] });
+
+  let capturedClientUser = "";
+  server.events.on("request:start", (request) => {
+    const { body } = request;
+    if (Array.isArray(body) && body.length > 0) {
+      capturedClientUser = body[0].clientUser;
+    }
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TelemetryDeckProvider telemetryDeck={td}>{children}</TelemetryDeckProvider>
+  );
+
+  const { result: { current: { signal } } } = renderHook(() => useTelemetryDeck(), { wrapper: Wrapper });
+  await signal("signal with default user");
+
+  expect(capturedClientUser).toBeDefined();
+  expect(capturedClientUser).not.toBe("");
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,39 @@
+import TelemetryDeck, { TelemetryDeckOptions } from "@telemetrydeck/sdk";
+import { BrowserPlugin } from "./plugins";
+
+type PayloadEnhancer = (payload: Record<string, unknown>) => Record<string, unknown>;
+
+type TelemetryDeckReactSDKPlugin = {
+  (next: PayloadEnhancer): PayloadEnhancer,
+  name?: string,
+};
+type TelemetryDeckReactSDKOptions = TelemetryDeckOptions & {
+  plugins?: TelemetryDeckReactSDKPlugin[],
+};
+
+type TelemetryDeckReactSDK = TelemetryDeck & {
+  payloadEnhancer?: PayloadEnhancer,
+};
+
+type BaseOptions = Omit<TelemetryDeckReactSDKOptions, "appID" | "clientUser" | "plugins">;
+
+type OptionsWithBrowserPlugin = BaseOptions & {
+  appID: string,
+  plugins: [BrowserPlugin, ...TelemetryDeckReactSDKPlugin[]] | [...TelemetryDeckReactSDKPlugin[], BrowserPlugin],
+  clientUser?: string,
+};
+
+type OptionsWithRequiredUser = BaseOptions & {
+  appID: string,
+  plugins?: TelemetryDeckReactSDKPlugin[],
+  clientUser: string,
+};
+
+export {
+  PayloadEnhancer,
+  TelemetryDeckReactSDKPlugin,
+  TelemetryDeckReactSDKOptions,
+  TelemetryDeckReactSDK,
+  OptionsWithBrowserPlugin,
+  OptionsWithRequiredUser,
+};

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "0.4.0";
+export const LIB_VERSION = "0.5.0";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "include": ["src"],
   "compilerOptions": {
-    "module": "esnext",
+    "module": "commonjs",
     "lib": ["dom", "esnext"],
     "importHelpers": true,
     // output .d.ts declaration files for consumers
@@ -19,8 +19,6 @@
     // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    // use Node's module resolution algorithm, instead of the legacy TS one
-    "moduleResolution": "node",
     // transpile JSX to React.createElement
     "jsx": "react",
     // interop between ESM and CJS modules. Recommended by TS
@@ -37,5 +35,4 @@
     "baseUrl": "./",
     "resolveJsonModule": true,
   }
-
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "include": ["src"],
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,
     // output .d.ts declaration files for consumers
@@ -19,6 +19,8 @@
     // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    // use Node's module resolution algorithm, instead of the legacy TS one
+    "moduleResolution": "node",
     // transpile JSX to React.createElement
     "jsx": "react",
     // interop between ESM and CJS modules. Recommended by TS
@@ -35,4 +37,5 @@
     "baseUrl": "./",
     "resolveJsonModule": true,
   }
+
 }


### PR DESCRIPTION
Allow for not defining the client user when utilizing the browser plugin for the userClient to be generated from the userAgent,